### PR TITLE
Features set computer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,17 @@ lazy val syntactic = project
     )
   )
 
+lazy val featuresSetComputer = project
+  .in(file("features-set-computer"))
+  .settings(
+    moduleName := "features-set-computer",
+    libraryDependencies ++= Seq(
+      scalameta,
+      junit,
+      junitInterface
+    )
+  ).dependsOn(syntactic)
+
 lazy val testsShared = project
   .in(file("tests/shared"))
 

--- a/features-set-computer/src/main/scala/FeaturesSetComputer.scala
+++ b/features-set-computer/src/main/scala/FeaturesSetComputer.scala
@@ -4,16 +4,38 @@ import syntactic.whitelist.{Feature, WhitelistChecker}
 import scala.collection.compat.immutable.LazyList
 import scala.meta.Tree
 
+/**
+ * Given a set of available Features, computes the minimal set of Features needed by a WhitelistChecker to allow
+ * a given set of language constructs
+ * @param availableFeatures the features that can be included in the computed set
+ */
 class FeaturesSetComputer(availableFeatures: List[Feature]) {
 
+  /**
+   * Computes the minimal set of Features needed by a WhitelistChecker to allow all the nodes in the given tree
+   * @param tree the tree whose nodes should be allowed
+   * @return the said minimal set of Features, wrapped in a Some, if it exists, otherwise None
+   */
   def minimalFeaturesSetFor(tree: Tree): Option[Set[Feature]] = {
     minimalFeaturesSetFor(tree.collect { case tree => tree })
   }
 
+  /**
+   * Assuming that a WhitelistChecker with the set of Features S1 rejected a program outputting the provided set of
+   * Violations, computes the minimal set S2 of Features s.t. a WhitelistChecker with with features S1 U S2
+   * will accept the program
+   * @param violations the violations reported by the checker with the incomplete set of features (S1)
+   * @return the set (S2) of additionally required features, wrapped in a Some, if it exists, otherwise None
+   */
   def minimalFeaturesSetToResolve(violations: List[Violation]): Option[Set[Feature]] = {
     minimalFeaturesSetFor(violations.map(_.forbiddenNode))
   }
 
+  /**
+   * Computes the minimal set of Features needed by a WhitelistChecker to allow all the provided nodes
+   * @param nodes the nodes to be allowed
+   * @return the said minimal set of Features, wrapped in a Some, if it exists, otherwise None
+   */
   def minimalFeaturesSetFor(nodes: List[Tree]): Option[Set[Feature]] = {
 
     def search(currentlySelectedFeatures: Set[Feature]): Option[Set[Feature]] = {

--- a/features-set-computer/src/main/scala/FeaturesSetComputer.scala
+++ b/features-set-computer/src/main/scala/FeaturesSetComputer.scala
@@ -1,0 +1,32 @@
+import syntactic.Violation
+import syntactic.whitelist.{Feature, WhitelistChecker}
+
+import scala.collection.compat.immutable.LazyList
+import scala.meta.Tree
+
+class FeaturesSetComputer(availableFeatures: List[Feature]) {
+
+  def minimalFeaturesSetFor(tree: Tree): Option[Set[Feature]] = {
+    minimalFeaturesSetFor(tree.collect { case tree => tree })
+  }
+
+  def minimalFeaturesSetToResolve(violations: List[Violation]): Option[Set[Feature]] = {
+    minimalFeaturesSetFor(violations.map(_.forbiddenNode))
+  }
+
+  def minimalFeaturesSetFor(nodes: List[Tree]): Option[Set[Feature]] = {
+
+    def search(currentlySelectedFeatures: Set[Feature]): Option[Set[Feature]] = {
+      val checker = WhitelistChecker(currentlySelectedFeatures.toList)
+      if (nodes.forall(checker.checkTree(_).isEmpty)){
+        val oneFeatureRemovedSubsets =
+          for (feature <- currentlySelectedFeatures.to[LazyList]) yield currentlySelectedFeatures - feature
+        oneFeatureRemovedSubsets.map(subset => search(subset)).find(_.nonEmpty).getOrElse(Some(currentlySelectedFeatures))
+      }
+      else None
+    }
+
+    search(availableFeatures.toSet)
+  }
+
+}

--- a/features-set-computer/src/test/scala/FeaturesSetComputerTest.scala
+++ b/features-set-computer/src/test/scala/FeaturesSetComputerTest.scala
@@ -1,9 +1,9 @@
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import syntactic.{CheckResult, Violation}
+import syntactic.CheckResult
 import syntactic.whitelist.{PredefFeatures, WhitelistChecker}
 
-import scala.meta.{Defn, Source, XtensionParseInputLike}
+import scala.meta.{Source, XtensionParseInputLike}
 
 class FeaturesSetComputerTest {
 

--- a/features-set-computer/src/test/scala/FeaturesSetComputerTest.scala
+++ b/features-set-computer/src/test/scala/FeaturesSetComputerTest.scala
@@ -1,0 +1,58 @@
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import syntactic.{CheckResult, Violation}
+import syntactic.whitelist.{PredefFeatures, WhitelistChecker}
+
+import scala.meta.{Defn, Source, XtensionParseInputLike}
+
+class FeaturesSetComputerTest {
+
+  private def parse(codeStr: String): Source = codeStr.parse[Source].get
+
+  @Test
+  def featuresSetComputationFromTree(): Unit = {
+    val codeStr =
+      """
+        |object Main {
+        |  def main(args: Array[String]): Unit = {
+        |    println("Hello world")
+        |  }
+        |}
+        |""".stripMargin
+    val src = parse(codeStr)
+    val exp = Some(Set(
+      PredefFeatures.LiteralsAndExpressions,
+      PredefFeatures.Defs,
+      PredefFeatures.PolymorphicTypes,
+      PredefFeatures.ADTs
+    ))
+    val featuresSetComputer = new FeaturesSetComputer(PredefFeatures.allDefinedFeatures)
+    assertEquals(exp, featuresSetComputer.minimalFeaturesSetFor(src))
+  }
+
+  @Test
+  def featuresSetComputationFromViolations(): Unit = {
+    val codeStr =
+      """
+        |object Foo {
+        |  def bar(z: String): Unit = {
+        |    val x = 5 + 42 + z.length
+        |    val y = f(x, 0)
+        |    println(y)
+        |    var u = 1
+        |    u += 2
+        |    println(u)
+        |  }
+        |}
+        |""".stripMargin
+    val src = parse(codeStr)
+    val initChecker = WhitelistChecker(PredefFeatures.LiteralsAndExpressions, PredefFeatures.ADTs)
+    val checkResult = initChecker.checkSource(src)
+    assert(checkResult.isInstanceOf[CheckResult.Invalid])
+    val featuresSetComputer = new FeaturesSetComputer(PredefFeatures.allDefinedFeatures)
+    val requiredFeatures = featuresSetComputer.minimalFeaturesSetToResolve(checkResult.asInstanceOf[CheckResult.Invalid].violations)
+    val exp = Some(Set(PredefFeatures.Vals, PredefFeatures.ImperativeConstructs, PredefFeatures.Defs))
+    assertEquals(exp, requiredFeatures)
+  }
+
+}

--- a/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
+++ b/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
@@ -21,10 +21,14 @@ trait FeaturesProvider {
       .members
       .filter(_.isPublic)
       .filter(_.isModule)
-      // TODO either one or the other of the two lines (and if relying on type then change the exception in the PF below)
+
+      // TODO either one or the other of both lines
+      // first line relies on an annotation
+      // second line includes all public Features in the list (would require to change the exception type in the PF below)
       .filter(_.annotations.exists(_.tree.tpe =:= mirror.typeOf[ScalaFeature]))
       //.filter(_.asModule.typeSignature <:< mirror.typeOf[Feature])
       .map(member => mirror.reflectModule(member.asModule).instance)
+
     val modules = modulesWithUncheckedType.map {
       case feature: Feature => feature
       case any => throw new AnnotationTypeMismatchException(null, any.getClass.getName)

--- a/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
+++ b/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
@@ -14,7 +14,9 @@ trait FeaturesProvider {
       .members
       .filter(_.isPublic)
       .filter(_.isModule)
+      // TODO either one or the other of the two lines (and if relying on type then change the exception in the PF below)
       .filter(_.annotations.exists(_.tree.tpe =:= mirror.typeOf[ScalaFeature]))
+      //.filter(_.asModule.typeSignature <:< mirror.typeOf[Feature])
       .map(member => mirror.reflectModule(member.asModule).instance)
     val modules = modulesWithUncheckedType.map {
       case feature: Feature => feature

--- a/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
+++ b/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
@@ -1,0 +1,28 @@
+package syntactic.whitelist
+
+import java.lang.annotation.AnnotationTypeMismatchException
+import scala.annotation.ClassfileAnnotation
+
+trait FeaturesProvider {
+
+  val allDefinedFeatures: List[Feature] = {
+    val clazz = getClass
+    val mirror = scala.reflect.runtime.universe.runtimeMirror(clazz.getClassLoader)
+    val modulesWithUncheckedType = mirror
+      .classSymbol(clazz)
+      .info
+      .members
+      .filter(_.isPublic)
+      .filter(_.isModule)
+      .filter(_.annotations.exists(_.tree.tpe =:= mirror.typeOf[ScalaFeature]))
+      .map(member => mirror.reflectModule(member.asModule).instance)
+    val modules = modulesWithUncheckedType.map {
+      case feature: Feature => feature
+      case any => throw new AnnotationTypeMismatchException(null, any.getClass.getName)
+    }
+    modules.toList
+  }
+
+}
+
+class ScalaFeature() extends ClassfileAnnotation

--- a/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
+++ b/syntactic/src/main/scala/syntactic/whitelist/FeaturesProvider.scala
@@ -3,8 +3,15 @@ package syntactic.whitelist
 import java.lang.annotation.AnnotationTypeMismatchException
 import scala.annotation.ClassfileAnnotation
 
+/**
+ * When implemented by a class that defines Features, automatically provides a list of all the features
+ * defined in the class that are annotated with @ScalaFeature
+ */
 trait FeaturesProvider {
 
+  /**
+   * All the features defined in this class that are annotated with @ScalaFeature
+   */
   val allDefinedFeatures: List[Feature] = {
     val clazz = getClass
     val mirror = scala.reflect.runtime.universe.runtimeMirror(clazz.getClassLoader)
@@ -27,4 +34,9 @@ trait FeaturesProvider {
 
 }
 
+/**
+ * Marks the Features that should be considered by the automatic building of a list of defined Features
+ *
+ * Only intended to be used on singleton objects extending the Feature interface
+ */
 class ScalaFeature() extends ClassfileAnnotation

--- a/syntactic/src/main/scala/syntactic/whitelist/PredefFeatures.scala
+++ b/syntactic/src/main/scala/syntactic/whitelist/PredefFeatures.scala
@@ -4,11 +4,12 @@ import syntactic.whitelist.Feature.{AtomicFeature, CompositeFeature}
 
 import scala.meta._
 
-object Features {
+object PredefFeatures extends FeaturesProvider {
 
   /**
    * Allows literals of basic types, including Unit and tuples, as well as expressions
    */
+  @ScalaFeature
   case object LiteralsAndExpressions extends AtomicFeature({
     case _: Lit.Boolean => true
     case _: Lit.Byte => true
@@ -34,6 +35,7 @@ object Features {
   /**
    * Allows the use of the null literal
    */
+  @ScalaFeature
   case object Nulls extends AtomicFeature({
     case _: Lit.Null => true
   })
@@ -41,6 +43,7 @@ object Features {
   /**
    * Allows the use of vals
    */
+  @ScalaFeature
   case object Vals extends AtomicFeature({
     case _: Decl.Val => true
     case _: Defn.Val => true
@@ -51,6 +54,7 @@ object Features {
   /**
    * Allows the use of defs
    */
+  @ScalaFeature
   case object Defs extends AtomicFeature({
     case _: Decl.Def => true
     case _: Defn.Def => true
@@ -64,6 +68,7 @@ object Features {
    * sealed traits, enums
    * Also allows objects (and not only case objects) for convenience (e.g. companion objects)
    */
+  @ScalaFeature
   case object ADTs extends AtomicFeature({
     case Defn.Class(modifiers, _, _, _, _) => modifiers.exists {
       case Mod.Case() => true
@@ -105,6 +110,7 @@ object Features {
   /**
    * Allows the use of literal functions
    */
+  @ScalaFeature
   case object LiteralFunctions extends AtomicFeature({
     case _: Term.ContextFunction => true
     case _: Term.Function => true
@@ -120,6 +126,7 @@ object Features {
   /**
    * Allows fors and for-yields
    */
+  @ScalaFeature
   case object ForExpr extends AtomicFeature({
     case _: Term.For => true
     case _: Term.ForYield => true
@@ -130,6 +137,7 @@ object Features {
   /**
    * Allows polymorphism, including opaque types
    */
+  @ScalaFeature
   case object PolymorphicTypes extends AtomicFeature({
     case Mod.Opaque() => true
     case _: Decl.Type => true
@@ -146,6 +154,7 @@ object Features {
   /**
    * Allows lazy vals and by-name arguments
    */
+  @ScalaFeature
   case object Laziness extends AtomicFeature({
     case Mod.Lazy() => true
     case _: Type.ByName => true
@@ -178,6 +187,7 @@ object Features {
    * this allows basic object-oriented programming, including:
    * classes, traits, secondary constructors, access modifiers
    */
+  @ScalaFeature
   case object BasicOop extends CompositeFeature(ADTs, BasicOopAddition)
 
   /**
@@ -185,12 +195,14 @@ object Features {
    * this allows advanced object-oriented modifiers:
    * final, open, transparent, super, covariant, contravariant, transparent
    */
+  @ScalaFeature
   case object AdvancedOop extends CompositeFeature(BasicOop, AdvancedOOPAddition)
 
   /**
    * Allows the use of imperative constructs, including:
    * vars, try-throw-catches, return and while loops
    */
+  @ScalaFeature
   case object ImperativeConstructs extends AtomicFeature({
     case Mod.VarParam() => true
     case _: Decl.Var => true
@@ -209,6 +221,7 @@ object Features {
    * Allows the use of contextual constructs, including:
    * implicits, using, givens
    */
+  @ScalaFeature
   case object ContextualConstructs extends AtomicFeature({
     case Mod.Implicit() => true
     case Mod.Using() => true
@@ -225,6 +238,7 @@ object Features {
   /**
    * Allows the definition of extension groups and extension methods
    */
+  @ScalaFeature
   case object Extensions extends AtomicFeature({
     case _: Defn.ExtensionGroup => true
   })
@@ -232,6 +246,7 @@ object Features {
   /**
    * Allows the use of macro and metaprogramming-related constructs
    */
+  @ScalaFeature
   case object Metaprogramming extends AtomicFeature({
     case _: Defn.Macro => true
     case _: Term.QuotedMacroExpr => true
@@ -246,6 +261,7 @@ object Features {
   /**
    * Allows the use of packages
    */
+  @ScalaFeature
   case object Packages extends AtomicFeature({
     case _: Pkg => true
     case _: Pkg.Object => true
@@ -254,6 +270,7 @@ object Features {
   /**
    * Allows the use of imports
    */
+  @ScalaFeature
   case object Imports extends AtomicFeature({
     case _: Import => true
     case _: Importee => true
@@ -264,6 +281,7 @@ object Features {
   /**
    * Allows export clauses
    */
+  @ScalaFeature
   case object Exports extends AtomicFeature({
     case _: Export => true
     case _: Importee => true
@@ -274,6 +292,7 @@ object Features {
   /**
    * Allows the use of XML-related constructs
    */
+  @ScalaFeature
   case object Xml extends AtomicFeature({
     case _: Term.Xml => true
     case _: Pat.Xml => true
@@ -283,6 +302,7 @@ object Features {
   /**
    * Allows string interpolation
    */
+  @ScalaFeature
   case object StringInterpolation extends AtomicFeature({
     case _: Term.Interpolate => true
     case _: Pat.Interpolate => true
@@ -291,6 +311,7 @@ object Features {
   /**
    * Allows annotations
    */
+  @ScalaFeature
   case object Annotations extends AtomicFeature({
     case _: Term.Annotate => true
     case _: Mod.Annot => true
@@ -299,6 +320,7 @@ object Features {
   /**
    * Allows to define infix methods
    */
+  @ScalaFeature
   case object Infixes extends AtomicFeature({
     case Mod.Infix() => true
   })
@@ -306,6 +328,7 @@ object Features {
   /**
    * Allows to define inline methods
    */
+  @ScalaFeature
   case object Inlines extends AtomicFeature({
     case Mod.Inline() => true
   })

--- a/syntactic/src/test/scala/syntactic/whitelist/WhitelistCheckerTestRunner.scala
+++ b/syntactic/src/test/scala/syntactic/whitelist/WhitelistCheckerTestRunner.scala
@@ -1,7 +1,7 @@
 package syntactic.whitelist
 
 import org.junit.Assert.{assertEquals, assertTrue, fail}
-import syntactic.whitelist.Features._
+import syntactic.whitelist.PredefFeatures._
 import syntactic.{CheckResult, Violation}
 
 import java.util.StringJoiner

--- a/syntactic/src/test/scala/syntactic/whitelist/WhitelistCheckerTests.scala
+++ b/syntactic/src/test/scala/syntactic/whitelist/WhitelistCheckerTests.scala
@@ -1,7 +1,7 @@
 package syntactic.whitelist
 
 import org.junit.Test
-import syntactic.whitelist.Features._
+import syntactic.whitelist.PredefFeatures._
 import syntactic.whitelist.WhitelistCheckerTestRunner.{expectInvalidWhenExcludingFeatures, expectParsingError, expectValidWithFeatures}
 
 import scala.meta.dialects


### PR DESCRIPTION
As we discussed on Discord and IRL, I implemented a system that, given a set of available `Feature`s, computes the minimal set of `Feature`s needed by a `WhitelistChecker` to accept a given program. I also renamed the `Features` object into `PredefFeatures`, for clarity.

To use this system, we need to be able to list available `Feature`s. I can think of 3 ways of doing that:
1. Simply let the user manually build the list of the `Feature`s that they defined, and define one such list in `PredefFeatures`. This is the most obvious solution, but if the user defines a lot of `Feature`s it becomes really easy to forget to include a `Feature` in the list;
2. Create a `FeaturesProvider` trait in the `syntactic` package that should be implemented by the classes in which `Feature`s are defined (including `PredefFeatures`), and use reflection in `FeaturesProvider` to get all the `Feature`s defined in the class (i.e. the singleton objects that inherit the `Feature` trait) and automatically build a list with all of them;
3. Create a `FeaturesProvider` trait in the `syntactic` package that should be implemented by the classes in which `Feature`s are defined (including `PredefFeatures`), and use an annotation to mark the `Feature`s that should be included in the list (again, the list would be obtained by using reflection in the `FeaturesProvider` trait).

The current implementation in this PR uses the third solution. I think that the first one is very impractical and that it is worth it automatically building the list of defined `Feature`s, but this implies using reflection and I am wondering if that is a problem (as far as I have tested it works well). Also, in case that is acceptable, is it better to include in the list all the `Feature`s that are defined in the class (solution 2) or to use an annotation (solution 3)? I wrote a comment in the implementation of `FeaturesProvider` that shows the (small) change that would be needed to switch from solution 3 to solution 2.